### PR TITLE
gitignore_change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 
 # Ignore Byebug command history file.
 .byebug_history
+public/uploads/*


### PR DESCRIPTION
public/uploads/*をgitnoneに追記。
この時点でrubyのversionが2.3.1であることを確認。